### PR TITLE
Use lower node version for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,10 @@
       "updateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     }
-  ]
+  ],
+  "force": {
+    "constraints": {
+      "node": "< 15.0.0"
+    }
+  }  
 }


### PR DESCRIPTION
Constrain node version in renovate so they won't generate package.lock v2 just yet.